### PR TITLE
Ensure $HOME/.config/sevenbridges/benten/ exists

### DIFF
--- a/benten/configuration.py
+++ b/benten/configuration.py
@@ -39,6 +39,9 @@ class Configuration(configparser.ConfigParser):
         self.log_path = P(os.getenv(xdg_data_home["env"], xdg_data_home["default"]), sbg_config_dir, "logs")
         self.scratch_path = P(os.getenv(xdg_data_home["env"], xdg_data_home["default"]), sbg_config_dir, "scratch")
 
+        if not self.cfg_path.exists():
+            self.cfg_path.mkdir(parents=True)        
+        
         if not self.log_path.exists():
             self.log_path.mkdir(parents=True)
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -29,6 +29,7 @@ def test_basic(monkeypatch):
     config = Configuration()
     config.initialize()
 
+    assert config.cfg_path.exists()    
     assert config.log_path.exists()
     assert config.scratch_path.exists()
 


### PR DESCRIPTION
Avoids error on startup:

```
INFO:root:Copying language schema files ...
Traceback (most recent call last):
  File "/home/stain/miniconda3/envs/benten/bin/benten-ls", line 8, in <module>
    sys.exit(main())
  File "/home/stain/miniconda3/envs/benten/lib/python3.8/site-packages/benten/__main__.py", line 67, in main
    config.initialize()
  File "/home/stain/miniconda3/envs/benten/lib/python3.8/site-packages/benten/configuration.py", line 54, in initialize
    self._copy_missing_language_files()
  File "/home/stain/miniconda3/envs/benten/lib/python3.8/site-packages/benten/configuration.py", line 81, in _copy_missing_language_files
    shutil.copy(src_file, dst_file)
  File "/home/stain/miniconda3/envs/benten/lib/python3.8/shutil.py", line 409, in copy
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/home/stain/miniconda3/envs/benten/lib/python3.8/shutil.py", line 259, in copyfile
    with open(src, 'rb') as fsrc, open(dst, 'wb') as fdst:
FileNotFoundError: [Errno 2] No such file or directory: '/home/stain/.config/sevenbridges/benten/schema-v1.0.json'
```