### PR TITLE
Add script to build using 'manylinux'

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -24,8 +24,7 @@ jobs:
     - name: Build using manylinux
       if: matrix.os == 'ubuntu-latest'
       run: |
-        cd package
-        bash build-manylinux.sh
+        bash package/build-manylinux.sh
     - name: Build without manylinux
       if: matrix.os != 'ubuntu-latest'
       run: |

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -25,7 +25,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: |
         cd package
-        sh build-manylinux.sh
+        bash build-manylinux.sh
     - name: Build without manylinux
       if: matrix.os != 'ubuntu-latest'
       run: |

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -22,9 +22,12 @@ jobs:
         pip install pyinstaller==4.0
         pip install .
         cd package
-        pyinstaller benten-ls.spec
-        python tgz.py
-
+        if [ "$RUNNER_OS" == "Linux" ]; then
+          sh build-manylinux.sh
+        else
+          pyinstaller benten-ls.spec
+          python tgz.py
+        fi
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -37,10 +37,3 @@ jobs:
       with:
         name: benten-ls-${{ matrix.os }}
         path: package/dist/benten-ls.tar.gz
-
-    - name: (Temporary) upload build directory
-      if: matrix.os == 'ubuntu-latest'
-      uses: actions/upload-artifact@v2
-      with:
-        name: benten-ls-${{ matrix.os }}
-        path: package/build/*

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -37,3 +37,10 @@ jobs:
       with:
         name: benten-ls-${{ matrix.os }}
         path: package/dist/benten-ls.tar.gz
+
+    - name: (Temporary) upload build directory
+      if: matrix.os == 'ubuntu-latest'
+      uses: actions/upload-artifact@v2
+      with:
+        name: benten-ls-${{ matrix.os }}
+        path: package/build/*

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -16,18 +16,23 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install and build
+    - name: Install
       run: |
         python -m pip install --upgrade pip
         pip install pyinstaller==4.0
         pip install .
+    - name: Build using manylinux
+      if: matrix.os == 'ubuntu-latest'
+      run: |
         cd package
-        if [ "$RUNNER_OS" == "Linux" ]; then
-          sh build-manylinux.sh
-        else
-          pyinstaller benten-ls.spec
-          python tgz.py
-        fi
+        sh build-manylinux.sh
+    - name: Build without manylinux
+      if: matrix.os != 'ubuntu-latest'
+      run: |
+        cd package
+        pyinstaller benten-ls.spec
+        python tgz.py
+
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:

--- a/benten/version.py
+++ b/benten/version.py
@@ -1,3 +1,3 @@
 #  Copyright (c) 2019-2021 Seven Bridges. See LICENSE
 
-__version__ = "2021.1.22"
+__version__ = "2021.1.25"

--- a/benten/version.py
+++ b/benten/version.py
@@ -1,3 +1,3 @@
 #  Copyright (c) 2019-2021 Seven Bridges. See LICENSE
 
-__version__ = "2021.1.5"
+__version__ = "2021.1.22"

--- a/package/benten-ls.spec
+++ b/package/benten-ls.spec
@@ -1,13 +1,17 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+import sys
 from benten.version import __version__
 
 block_cipher = None
 
+binaries=[]
+if sys.platform == 'linux':
+    binaries.append(('/usr/local/lib/libcrypt.so.2', '.'))
 
 a = Analysis(['benten-ls.py'],
              pathex=[],
-             binaries=[('/usr/local/lib/libcrypt.so.2', '.')],
+             binaries=binaries,
              datas=[("../benten_schemas/*", "benten_schemas")],
              hiddenimports=[],
              hookspath=["."],

--- a/package/benten-ls.spec
+++ b/package/benten-ls.spec
@@ -7,7 +7,7 @@ block_cipher = None
 
 a = Analysis(['benten-ls.py'],
              pathex=[],
-             binaries=[],
+             binaries=[('/usr/local/lib/libcrypt.so.2', '.')],
              datas=[("../benten_schemas/*", "benten_schemas")],
              hiddenimports=[],
              hookspath=["."],

--- a/package/build-manylinux.sh
+++ b/package/build-manylinux.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+if [[ $1 != "--inside" ]]; then
+    exec docker run --rm -v$PWD:/benten -w/benten quay.io/tetron/manylinux2010_x86_64:fc5d4309b9cff6e58a2d0e5d9d4eba0c797c655b /benten/package/build-manylinux.sh --inside
+fi
+
+set -xe
+
+export LD_LIBRARY_PATH=/usr/local/lib:/opt/python/cp38-cp38/lib
+
+rm -rf bvenv
+/opt/python/cp38-cp38/bin/python -m venv bvenv
+. bvenv/bin/activate
+
+pip install .
+pip install pyinstaller==4.0
+
+cd package
+rm -rf dist
+pyinstaller --add-binary '/usr/local/lib/libcrypt.so.2:.' benten-ls.spec
+python tgz.py

--- a/package/build-manylinux.sh
+++ b/package/build-manylinux.sh
@@ -16,5 +16,5 @@ pip install pyinstaller==4.0
 
 cd package
 rm -rf dist
-pyinstaller --add-binary '/usr/local/lib/libcrypt.so.2:.' benten-ls.spec
+pyinstaller benten-ls.spec
 python tgz.py

--- a/vscode-client/Readme.md
+++ b/vscode-client/Readme.md
@@ -26,5 +26,5 @@ from `github`.
 For more detailed information please see the [project page](https://github.com/rabix/benten).
 
 <div align="right">
-<sub>(c) 2019 Seven Bridges Genomics. Rabix is a registered trademark of Seven Bridges Genomics</sub>
+<sub>(c) 2019-2021 Seven Bridges Genomics. Rabix is a registered trademark of Seven Bridges Genomics</sub>
 </div>

--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -3,7 +3,7 @@
   "publisher": "sbg-rabix",
   "displayName": "CWL (Rabix/Benten)",
   "description": "Autocomplete, code validation and more for CWL documents",
-  "version": "2021.1.22",
+  "version": "2021.1.25",
   "preview": false,
   "icon": "benten-icon-128px.png",
   "galleryBanner": {

--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -3,7 +3,7 @@
   "publisher": "sbg-rabix",
   "displayName": "CWL (Rabix/Benten)",
   "description": "Autocomplete, code validation and more for CWL documents",
-  "version": "2021.1.5",
+  "version": "2021.1.22",
   "preview": false,
   "icon": "benten-icon-128px.png",
   "galleryBanner": {


### PR DESCRIPTION
Use a slightly modified fork of the 'manylinux' Docker image to achive
binary support over the widest possible range of Linux distributions.

The github action Linux build should use this instead of calling pyinstaller directly.

I recommend making a new release after this is merged since so we have more portable Linux binaries, this is specifically intended to fix #110.